### PR TITLE
Disable altering metatags if user is authenticated

### DIFF
--- a/iq_faq.module
+++ b/iq_faq.module
@@ -13,7 +13,9 @@ use Drupal\Core\Url;
  * Read FAQ data from rendered node content and add it to metatags.
  */
 function iq_faq_metatags_alter(array &$metatags) {
-
+  if (\Drupal::currentUser()->isAuthenticated()) {
+    return;
+  }
   // Only process metatags on GET requests.
   if (\Drupal::request()->getMethod() !== 'GET') {
     return;

--- a/iq_faq.module
+++ b/iq_faq.module
@@ -13,9 +13,11 @@ use Drupal\Core\Url;
  * Read FAQ data from rendered node content and add it to metatags.
  */
 function iq_faq_metatags_alter(array &$metatags) {
+  // Disable iq_faq non-anonymous requests.
   if (\Drupal::currentUser()->isAuthenticated()) {
     return;
   }
+
   // Only process metatags on GET requests.
   if (\Drupal::request()->getMethod() !== 'GET') {
     return;


### PR DESCRIPTION
This PR disables any alteration of metatags for authenticated users. This improves performance as it prevents rendering the page twice and should not have any detrimental effects on functionality, as it is only needed for anonymous requests.