### PR TITLE
Fix issue where FAQ schema.org data was overriding other data

### DIFF
--- a/src/FaqMetatagBuilder.php
+++ b/src/FaqMetatagBuilder.php
@@ -140,8 +140,10 @@ class FaqMetatagBuilder implements TrustedCallbackInterface {
       if ((empty($faqs[0]['name']) || $faqs = NULL) && count($schema['@graph']) <= 1) {
         $result = '';
       }
-      $cache_bin->set($cid, $result, Cache::PERMANENT, self::$tags);
-      return Markup::create($result);
+      if ($result) {
+        $cache_bin->set($cid, $result, Cache::PERMANENT, self::$tags);
+        return Markup::create($result);
+      }
     }
     return $markup_object;
   }


### PR DESCRIPTION
## Summary

This pull request fixes an issue where **schema.org metatags that are not FAQ elements** were unintentionally removed from the markup.

## Root Cause

The `postRenderHtmlTag` method in `src/FaqMetatagBuilder.php` cached and returned `$result` even when it was empty. This led to unnecessary cache writes and caused non-FAQ schema.org metatags to be removed from the markup.

## Changes

### Improved result handling and caching logic

- Updated the `postRenderHtmlTag` method in `src/FaqMetatagBuilder.php`.
- Added a conditional check to ensure that caching and returning of `$result` only occurs when `$result` is non-empty.
- Prevented unnecessary cache writes.
- Avoided potential issues caused by empty results.

## Result

Non-FAQ schema.org metatags are now preserved in the markup, and caching behavior is more robust and predictable.